### PR TITLE
Emitter backflow option

### DIFF
--- a/epanet2w/Ddefault.pas
+++ b/epanet2w/Ddefault.pas
@@ -171,7 +171,13 @@ begin
        PropList[I].Add(DefProp[PIPES].Data[PIPE_ROUGH_INDEX]);
      end;
   2: begin
-       for j := FLOW_UNITS_INDEX to STATUS_RPT_INDEX do
+       for j := FLOW_UNITS_INDEX to EMITTER_EXP_INDEX do
+         PropList[I].Add(Network.Options.Data[j]);
+       PropList[I].Add(Network.Options.Data[EMITTER_BACK_INDEX]);
+       PropList[I].Add(Network.Options.Data[STATUS_RPT_INDEX]);
+       for j := HEAD_ERROR_INDEX to PRESSURE_EXP_INDEX do
+         PropList[I].Add(Network.Options.Data[j]);
+       for j := CHECK_FREQ_INDEX to DAMP_LIMIT_INDEX do
          PropList[I].Add(Network.Options.Data[j]);
      end;
   end;
@@ -213,8 +219,15 @@ begin
   DefProp[PIPES].Data[PIPE_DIAM_INDEX] := PropList[1].Strings[5];
   DefProp[PIPES].Data[PIPE_ROUGH_INDEX] := PropList[1].Strings[6];
   DefProp[VALVES].Data[VALVE_DIAM_INDEX] := DefProp[PIPES].Data[PIPE_DIAM_INDEX];
-  for j := FLOW_UNITS_INDEX to STATUS_RPT_INDEX do
+
+  for j := FLOW_UNITS_INDEX to EMITTER_EXP_INDEX do
     Network.Options.Data[j] := PropList[2].Strings[j-FLOW_UNITS_INDEX];
+  Network.Options.Data[EMITTER_BACK_INDEX] := PropList[2].Strings[10];
+  Network.Options.Data[STATUS_RPT_INDEX] := PropList[2].Strings[11];
+  for j := HEAD_ERROR_INDEX to PRESSURE_EXP_INDEX do
+    Network.Options.Data[j] := PropList[2].Strings[12+j-HEAD_ERROR_INDEX];
+  for j := CHECK_FREQ_INDEX to DAMP_LIMIT_INDEX do
+    Network.Options.Data[j] := PropList[2].Strings[18+j-CHECK_FREQ_INDEX];
 
   Uinput.UpdateAllUnits;
 

--- a/epanet2w/Ddisclaimer.dfm
+++ b/epanet2w/Ddisclaimer.dfm
@@ -3,7 +3,7 @@ object DisclaimerForm: TDisclaimerForm
   Top = 104
   BorderStyle = bsDialog
   Caption = 'EPANET Development Version Disclaimer'
-  ClientHeight = 329
+  ClientHeight = 480
   ClientWidth = 377
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -11,15 +11,13 @@ object DisclaimerForm: TDisclaimerForm
   Font.Height = -12
   Font.Name = 'Segoe UI'
   Font.Style = []
-  OldCreateOrder = False
   Position = poMainFormCenter
-  PixelsPerInch = 96
   TextHeight = 15
   object Panel1: TPanel
     Left = 24
     Top = 8
     Width = 337
-    Height = 281
+    Height = 433
     BevelInner = bvRaised
     BevelOuter = bvLowered
     TabOrder = 0
@@ -40,12 +38,12 @@ object DisclaimerForm: TDisclaimerForm
       IsControl = True
     end
     object Version: TLabel
-      Left = 146
+      Left = 106
       Top = 45
-      Width = 74
+      Width = 152
       Height = 14
       Alignment = taCenter
-      Caption = '2023-04-20'
+      Caption = 'GUI Version: 2024-03-01'
       Font.Charset = ANSI_CHARSET
       Font.Color = clWindowText
       Font.Height = -12
@@ -72,7 +70,7 @@ object DisclaimerForm: TDisclaimerForm
     end
     object Build: TLabel
       Left = 133
-      Top = 65
+      Top = 89
       Width = 102
       Height = 14
       Alignment = taCenter
@@ -82,6 +80,21 @@ object DisclaimerForm: TDisclaimerForm
       Font.Height = -12
       Font.Name = 'Tahoma'
       Font.Style = []
+      ParentFont = False
+      IsControl = True
+    end
+    object Label1: TLabel
+      Left = 86
+      Top = 65
+      Width = 172
+      Height = 14
+      Alignment = taCenter
+      Caption = 'Engine Version: 2023-06-08'
+      Font.Charset = ANSI_CHARSET
+      Font.Color = clWindowText
+      Font.Height = -12
+      Font.Name = 'Tahoma'
+      Font.Style = [fsBold]
       ParentFont = False
       IsControl = True
     end
@@ -213,9 +226,9 @@ object DisclaimerForm: TDisclaimerForm
     end
     object Memo1: TMemo
       Left = 9
-      Top = 85
+      Top = 120
       Width = 321
-      Height = 185
+      Height = 305
       BorderStyle = bsNone
       Color = clMenu
       Lines.Strings = (
@@ -234,13 +247,18 @@ object DisclaimerForm: TDisclaimerForm
         ''
         'The developers of this software are not responsible for any '
         'damage or loss caused by the use of this development '
-        'version.')
+        'version.'
+        ''
+        'Networks saved with a development version will not be'
+        'compatible with the standard release of the software or'
+        'with other development versions.')
+      ReadOnly = True
       TabOrder = 1
     end
   end
   object Button1: TButton
     Left = 157
-    Top = 295
+    Top = 447
     Width = 75
     Height = 25
     Caption = 'OK'

--- a/epanet2w/Ddisclaimer.pas
+++ b/epanet2w/Ddisclaimer.pas
@@ -17,6 +17,7 @@ type
     ProgramIcon: TImage;
     Button1: TButton;
     Memo1: TMemo;
+    Label1: TLabel;
   private
     { Private declarations }
   public

--- a/epanet2w/Fmain.pas
+++ b/epanet2w/Fmain.pas
@@ -41,7 +41,7 @@ const
   MSG_NO_BACKDROP = 'Could not find backdrop file ';
   MSG_FIND_BACKDROP = '. Do you want to search for it?';
 
-  TXT_MAIN_CAPTION = 'EPANET [DEV 2023-04-20]';
+  TXT_MAIN_CAPTION = 'EPANET [DEV 2024-03-01]';
   TXT_AUTOLENGTH = 'Auto-Length ';
   TXT_STATUS_REPORT = 'Status Report';
   TXT_SAVE_CHANGES = 'Save changes made to current project?';

--- a/epanet2w/Uexport.pas
+++ b/epanet2w/Uexport.pas
@@ -336,6 +336,7 @@ begin
   if (IOResult = 0) then
   try
 
+    Writeln(F,';INP saved using EPANET Development Preview version ',VERSIONDEV);
     Writeln(F,'[TITLE]');
     Writeln(F,Network.Options.Title);
     slist := Network.Options.Notes;

--- a/epanet2w/Uexport.pas
+++ b/epanet2w/Uexport.pas
@@ -742,6 +742,7 @@ begin
       end;
 
       Writeln(F,' Emitter Exponent   '#9,Data[EMITTER_EXP_INDEX]);
+      Writeln(F,' Emitter Backflow   '#9,Data[EMITTER_BACK_INDEX]);
       if UpperCase(Trim(Data[QUAL_PARAM_INDEX])) = 'TRACE' then
       Writeln(F,' Quality            '#9'Trace ',Data[TRACE_NODE_INDEX])
       else

--- a/epanet2w/Ufileio.pas
+++ b/epanet2w/Ufileio.pas
@@ -465,6 +465,11 @@ begin
             Network.Options.Data[i] := DefOptions[i];
         end;
 
+        if (Version < VERSIONDEV) then
+        begin
+          Network.Options.Data[EMITTER_BACK_INDEX] := DefOptions[EMITTER_BACK_INDEX];
+        end;
+
       //Check if Quality Time Step is in hours instead of minutes
         with Network.Options do
         begin

--- a/epanet2w/Ufileio.pas
+++ b/epanet2w/Ufileio.pas
@@ -165,7 +165,7 @@ begin
 
     //Write file header.
       WriteString('<EPANET2>');
-      WriteInteger(VERSIONID2);
+      WriteInteger(VERSIONDEV);
 
     //Write numbers of network components
       for i := JUNCS to CNTRLS do
@@ -436,7 +436,7 @@ begin
 
       //Read version ID
         Version := ReadInteger;
-        if (Version < VERSIONID1) or (Version > VERSIONID2) then
+        if (Version < VERSIONID1) or (Version > VERSIONDEV) then
         begin
           raise EReadError.Create(MSG_READ_ERR);
         end;

--- a/epanet2w/Uglobals.pas
+++ b/epanet2w/Uglobals.pas
@@ -63,7 +63,7 @@ const
   MAXINTERVALS = 4;  //Max. color scale interval index
   MAXNODEPROPS = 26; //Max. index for node property array
   MAXLINKPROPS = 25; //Max. index for link property array
-  MAXOPTIONS   = 44; //Max. index for network options array
+  MAXOPTIONS   = 45; //Max. index for network options array
   MAXSERIES    = 5;  //Max. time series plots per graph
   MAXCOLS      = 15; //Max. columns in a table
   MAXFILTERS   = 10; //Max. filter conditions for table
@@ -274,6 +274,8 @@ const
   MIN_PRESSURE_INDEX  = 42; //Minimum service pressure
   REQ_PRESSURE_INDEX  = 43; //Required service pressure
   PRESSURE_EXP_INDEX  = 44; //Exponent in demand v. pressure function
+
+  EMITTER_BACK_INDEX  = 45; //Emitter backflow
 
 //-----------------
 // Graph-type codes

--- a/epanet2w/Uglobals.pas
+++ b/epanet2w/Uglobals.pas
@@ -53,6 +53,8 @@ const
 //------------------
   VERSIONID1 = 20005;
   VERSIONID2 = 20201;
+  VERSIONDEV = 20240301; //Compile date
+
 
 //------------------
 // Maximum limits

--- a/epanet2w/Uimport.pas
+++ b/epanet2w/Uimport.pas
@@ -1215,9 +1215,13 @@ begin
          else Network.Options.Data[DEMAND_MULT_INDEX] := TokList[2];
        end;
 
-  // Emitter Exponent option
+  // Emitter Exponent or Emitter backflow option
     9: if Ntoks >= 3 then
-         Network.Options.Data[EMITTER_EXP_INDEX] := TokList[2];
+       begin
+         if CompareText(TokList[1], 'EXPONENT') = 0
+         then Network.Options.Data[EMITTER_EXP_INDEX] := TokList[2]
+         else Network.Options.Data[EMITTER_BACK_INDEX] := TokList[2];
+       end;
 
     3,  //Rel. Viscosity
     4,  //Max Trials

--- a/epanet2w/Uinifile.pas
+++ b/epanet2w/Uinifile.pas
@@ -295,9 +295,22 @@ begin
       IDPrefix[i] := ReadString('Labels',ObjectLabel[i],'');
 
   // Retrieve default hydraulic analysis options
-    for i := FLOW_UNITS_INDEX to STATUS_RPT_INDEX do
+    for i := FLOW_UNITS_INDEX to EMITTER_EXP_INDEX do
       Network.Options.Data[i] := ReadString('Hydraulics',
         HydraulicProps[i].Name,Network.Options.Data[i]);
+
+    Network.Options.Data[EMITTER_BACK_INDEX] := ReadString('Hydraulics',
+        HydraulicProps[10].Name,Network.Options.Data[EMITTER_BACK_INDEX]);
+    Network.Options.Data[STATUS_RPT_INDEX] := ReadString('Hydraulics',
+        HydraulicProps[11].Name,Network.Options.Data[STATUS_RPT_INDEX]);
+
+    for i := HEAD_ERROR_INDEX to PRESSURE_EXP_INDEX do
+      Network.Options.Data[i] := ReadString('Hydraulics',
+        HydraulicProps[12+i-HEAD_ERROR_INDEX].Name,Network.Options.Data[i]);
+
+    for i := CHECK_FREQ_INDEX to DAMP_LIMIT_INDEX do
+      Network.Options.Data[i] := ReadString('Hydraulics',
+        HydraulicProps[18+i-CHECK_FREQ_INDEX].Name,Network.Options.Data[i]);
 
   // Retrieve specific default node properties
     DefProp[JUNCS].Data[JUNC_ELEV_INDEX] :=
@@ -346,8 +359,21 @@ begin
       WriteString('Labels',ObjectLabel[i],IDPrefix[i]);
 
   // Save default hydraulic analysis options
-    for i := FLOW_UNITS_INDEX to STATUS_RPT_INDEX do
+    for i := FLOW_UNITS_INDEX to EMITTER_EXP_INDEX do
        WriteString('Hydraulics',HydraulicProps[i].Name,
+         Network.Options.Data[i]);
+    
+    WriteString('Hydraulics',HydraulicProps[10].Name,
+      Network.Options.Data[EMITTER_BACK_INDEX]);
+    WriteString('Hydraulics',HydraulicProps[11].Name,
+      Network.Options.Data[STATUS_RPT_INDEX]);
+
+    for i := HEAD_ERROR_INDEX to PRESSURE_EXP_INDEX do
+       WriteString('Hydraulics',HydraulicProps[12+i-HEAD_ERROR_INDEX].Name,
+         Network.Options.Data[i]);
+
+    for i := CHECK_FREQ_INDEX to DAMP_LIMIT_INDEX do
+       WriteString('Hydraulics',HydraulicProps[18+i-CHECK_FREQ_INDEX].Name,
          Network.Options.Data[i]);
 
   // Save specific default node properties

--- a/epanet2w/Uinput.pas
+++ b/epanet2w/Uinput.pas
@@ -646,8 +646,12 @@ begin
     begin
       case Index of
       0:  begin
-            for k := FLOW_UNITS_INDEX to STATUS_RPT_INDEX do //Hydraulics
+            for k := FLOW_UNITS_INDEX to EMITTER_EXP_INDEX do //Hydraulics
               PropList.Add(Data[k]);
+            
+            PropList.Add(Data[EMITTER_BACK_INDEX]);
+            PropList.Add(Data[STATUS_RPT_INDEX]);
+
             for k := HEAD_ERROR_INDEX to PRESSURE_EXP_INDEX do
               PropList.Add(Data[k]);
             for k := CHECK_FREQ_INDEX to DAMP_LIMIT_INDEX do
@@ -1499,9 +1503,10 @@ begin
   k := I;
   // Convert from editor index I to property index k
   case EditorIndex of
-    0: if I < 11 then k := I       //HYDRAULICS
-       else if I < 17 then k := HEAD_ERROR_INDEX + (I - 11)
-       else k := CHECK_FREQ_INDEX + (I - 17);
+    0: if I < 10 then k := I       //HYDRAULICS
+       else if I = 10 then k := EMITTER_BACK_INDEX
+       else if I < 17 then k := HEAD_ERROR_INDEX + (I - 12)
+       else k := CHECK_FREQ_INDEX + (I - 18);
 
     1: k := QUAL_PARAM_INDEX  + I;  //QUALITY
     2: k := BULK_ORDER_INDEX + I;   //REACTIONS

--- a/epanet2w/consts.txt
+++ b/epanet2w/consts.txt
@@ -204,7 +204,7 @@ const
     (Name:'Meter ID';       Style:esEdit;      Mask:emNoSpace;  Length:MAXID),
     (Name:'Font';           Style:esButton;    Mask:emNone));
 
-  HydraulicProps: array [0..19] of TPropRecord =
+  HydraulicProps: array [0..20] of TPropRecord =
     ((Name:'Flow Units';         Style:esComboList;  Mask:emNone; Length:0;
       List:'CFS'#13'GPM'#13'MGD'#13'IMGD'#13'AFD'#13 +
            'LPS'#13'LPM'#13'MLD'#13'CMH'#13'CMD'#13'CMS'),
@@ -219,6 +219,8 @@ const
      (Name:'Default Pattern';    Style:esEdit; Mask:emNoSpace;    Length:MAXID),
      (Name:'Demand Multiplier';  Style:esEdit; Mask:emPosNumber),
      (Name:'Emitter Exponent';   Style:esEdit; Mask:emPosNumber),
+     (Name:'Emitter Backflow';   Style:esComboList; Mask:emNone;  Length:0;
+      List:'Yes'#13'No'),
      (Name:'Status Report';      Style:esComboList; Mask:emNone;  Length:0;
       List:'No'#13'Yes'#13'Full'),
 
@@ -395,7 +397,9 @@ const
                      'DDA',         {41-Demand Model}
                      '0',           {42-Minimum Pressure}
                      '0.1',         {43-Required Pressure}
-                     '0.5');        {44-Pressure Exponent}
+                     '0.5',         {44-Pressure Exponent}
+                     
+                     'Yes');        {45-Emitter Backflow}
 
 //Node reporting variables
 //  Name         = name of variable


### PR DESCRIPTION
Adding a new option to the EPANET GUI may seem simple, but there are several considerations to take into account. I will use this pull request to outline the steps for adding a new option to the EPANET GUI for any future additions.

You should check these notes for each file against the changes in the PR.

**consts.txt**
- Add a new record to the` HydraulicProps` array; this is the order it is seen in the GUI from Data > Options > Hydraulic.
- Increase the size of the `HydraulicProps` array
- The order is not the same as the array used by `DefOptions` and `TOptions` (`Network.Options.Data`). In other files, we need magic numbers or complex logic to connect the `HydraulicProps` array to the `Network.Options.Data` and `DefOption`s array.
- Add a new record to the end of `DefOptions` that matches the internal array used by `TOptions`. It is necessary to add it to the end for backward compatibility (more on this later).
- `DefOptions` is the global default values for the options.

**Uglobals.pas**
- Increase the `MAXOPTIONS` size, which is used by both `TOptions` and `DefOptions`.
- Add a new analysis option index, which is used to find the correct place of the option in the internal memory.
- Bump the version number to determine if the .net file is compatible with the current version of EPANET (more on this later).

**Uinput.pas**
- Update the function `EditOptions` to align the `PropList` with `HydraulicProps` and `Network.Options.Data`.
- Update the function `ValidOption` that takes the index of the `PropList`, which matches `HydraulicProps`, and align it with Network.Options.Data.

**Uexport.pas**
- Update the function `ExportDataBase` to save the new option to the .inp file.

**Uimport.pas**
- Update the function `ReadOptionData` to read the new option from the .inp file.
- You may need to update the `OptionWords` array to identify the new option in the .inp file.

**Ufileio.pas**
- This file is used to read and write .net files; it saves a binary version of the internal Network structure. Because we are adding a new option, it won't be compatible with older versions of EPANET.
- It uses an internal `ReadArray`/`WriteArray` that saves the length of arrays and also checks it against the internal array length. However, this will cause a problem with older versions because it won't read all the strings in the binary file.
- For this reason, we need to bump the version number and add support to read old versions of .net files by assigning default values to the new options.
- We also need to consider how we handle compatibility between development versions. I'm tempted to not accept .net files from development versions to make things simpler.
- We could simplify things by aligning all three arrays (`HydraulicProps`, `DefOptions`, `TOptions`), but this would cause backward compatibility issues when reading .net files. However, this could be managed in Ufileio.pas.

**Uinifile.pas**
- Used to save the default values of the options to the .ini file.
- You need to update `ReadDefaults` and `SaveDefaults` to align the different arrays (`HydraulicProps`, `TOptions`).

**Ddefault.pas**
- You need to update `SetDefaults` and `GetDefaults` to align the different arrays (`HydraulicProps`, `TOptions`).
- This view changes the current network analysis options, and if you select "Save as defaults for all new projects," it will save the new option to the .ini file.

Closes #5 
Closes #14 
Closes #15